### PR TITLE
Fixing toBlock not being used correctly

### DIFF
--- a/events/blockchain.js
+++ b/events/blockchain.js
@@ -82,7 +82,7 @@ module.exports.get = async () => {
   var fromBlock = parseInt(Config.fromBlock) || 0;
   const blocksPerBatch = parseInt(Config.blocksPerBatch) || 0;
   const delay = parseInt(Config.delay) || 0;
-  const toBlock = blockHeight;
+  const toBlock = parseInt(Config.toBlock) || blockHeight;
 
   const lastDownloadedBlock = await LastDownloadedBlock.get(symbol);
 
@@ -94,10 +94,16 @@ module.exports.get = async () => {
   console.log("From %d to %d", fromBlock, toBlock);
 
   let start = fromBlock;
-  let end = fromBlock + blocksPerBatch;
+  let end = fromBlock;
   let i = 0;
 
   while (end < toBlock) {
+    end = start + blocksPerBatch;
+    
+    if(end > toBlock) {
+      end = toBlock;
+    }
+    
     i++;
 
     if (delay) {
@@ -109,11 +115,7 @@ module.exports.get = async () => {
     await tryGetEvents(start, end, symbol);
 
     start = end + 1;
-    end = start + blocksPerBatch;
-
-    if (end > toBlock) {
-      end = toBlock;
-    }
+    end = start;
   }
 
   // Hard disk writing is too slow, you need to wait, depending on the file system


### PR DESCRIPTION
Fixing `toBlock` parameter not being loaded in from config file, and fixing the final batch of blocks not being skipped over in the processing loop.

Without this, the `toBlock` parameter is ignored and always goes to `blockHeight`.

Additionally, the final batch of blocks being processed would be skipped because the loop checks if `end < toBlock`, without factoring in if part of that batch should still be included and processed.